### PR TITLE
Implement no_std compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,21 @@ repository = "https://github.com/safinsingh/color_conv"
 keywords = ["color", "rgb", "hex", "cmyk", "hsl"]
 
 [dependencies]
-thiserror = "1.0.24"
+thiserror = { version = "1.0", optional = true }
+num-traits = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
 anyhow = "1.0.38"
 rustyline = "7.1.0"
+
+[features]
+default = ["std"]
+
+# Uses the standard library
+std = ["thiserror"]
+
+# Enables no_std compatibility
+no_std = ["num-traits", "num-traits/libm"]
+
+# Uses f32 instead of f64 for floating point operations
+f32 = []

--- a/src/cmyk.rs
+++ b/src/cmyk.rs
@@ -1,5 +1,7 @@
-use crate::{Color, Error, Hsl, Rgb};
-use std::fmt;
+#[allow(unused_imports)]
+use crate::prelude::*;
+use crate::{Color, Error, Float, Hsl, Rgb};
+use core::fmt;
 
 ///
 /// A representation of the CMYK (cyan, magenta, yellow, key) color format.
@@ -81,7 +83,7 @@ impl fmt::Display for Cmyk {
 impl Color for Cmyk {
 	fn to_rgb(self) -> Rgb {
 		let apply =
-			|v| (255. * (1f64 - v as f64 / 100.) * (1. - self.key as f64 / 100.)).round() as u8;
+			|v| (255. * (1. - v as Float / 100.) * (1. - self.key as Float / 100.)).round() as u8;
 
 		let red = apply(self.cyan);
 		let green = apply(self.magenta);

--- a/src/hsl.rs
+++ b/src/hsl.rs
@@ -1,5 +1,7 @@
-use crate::{Cmyk, Color, Error, Rgb};
-use std::fmt;
+#[allow(unused_imports)]
+use crate::prelude::*;
+use crate::{Cmyk, Color, Error, Float, Rgb};
+use core::fmt;
 
 ///
 /// A representation of the HSL (cyan, magenta, yellow, key) color format.
@@ -95,10 +97,10 @@ macro_rules! exclusive_range_workaround {
 
 impl Color for Hsl {
 	fn to_rgb(self) -> Rgb {
-		let c = (1. - ((2. * (self.lightness as f64 / 100.)) - 1.).abs())
-			* (self.saturation as f64 / 100.);
-		let x = c * (1. - ((((self.hue as f64) / 60.) % 2.) - 1.).abs());
-		let m = (self.lightness as f64 / 100.) - (c / 2.);
+		let c = (1. - ((2. * (self.lightness as Float / 100.)) - 1.).abs())
+			* (self.saturation as Float / 100.);
+		let x = c * (1. - ((((self.hue as Float) / 60.) % 2.) - 1.).abs());
+		let m = (self.lightness as Float / 100.) - (c / 2.);
 
 		let (r_prime, g_prime, b_prime) = exclusive_range_workaround! { self,
 			0..60 => (c, x, 0.),
@@ -109,7 +111,7 @@ impl Color for Hsl {
 			300..360 => (c, 0., x)
 		};
 
-		let apply = |v: f64| ((v + m) * 255.).round() as u8;
+		let apply = |v: Float| ((v + m) * 255.).round() as u8;
 		let red = apply(r_prime);
 		let green = apply(g_prime);
 		let blue = apply(b_prime);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 	trivial_casts,
 	trivial_numeric_casts
 )]
+#![cfg_attr(feature = "no_std", no_std)]
 
 //!
 //! `color_conv` is a helper library for easily and programmatically converting
@@ -36,28 +37,60 @@ pub mod hsl;
 pub mod rgb;
 
 pub use self::{cmyk::Cmyk, hsl::Hsl, rgb::Rgb};
-use thiserror::Error as ThisError;
 
-#[derive(ThisError, Debug)]
-///
-/// Crate-wide Error type.
-///
-pub enum Error {
-	///
-	/// Occurs when a parameter representing a percentage value is greater than
-	/// 100. This error can be thrown by [`Cmyk::new`](crate::Cmyk::new) or
-	/// [`Hsl::new`](crate::Hsl::new), both of which perform this check.
-	///
-	#[error("Percentage overflow: value is larger than 100!")]
-	PercentageOverflow,
-	///
-	/// Occurs when a parameter representing a degree value is greater than 360.
-	/// 100. This error can be thrown by  [`Hsl::new`](crate::Hsl::new), which
-	/// performs this check.
-	///
-	#[error("Degree overflow: value is larger than 360!")]
-	DegreeOverflow,
+#[cfg(feature = "f32")]
+type Float = f32;
+#[cfg(not(feature = "f32"))]
+type Float = f64;
+
+#[cfg(feature = "no_std")]
+mod prelude {
+	pub use num_traits::Float as _;
+	pub use num_traits::FloatConst as _;
+
+	extern crate alloc;
+	pub use alloc::format;
+	pub use alloc::string::String;
+	pub use alloc::string::ToString;
+
+	/// Crate-wide Error type.
+	#[derive(Debug)]
+	pub enum Error {
+		/// Occurs when a parameter representing a percentage value is greater
+		/// than 100. This error can be thrown by
+		/// [`Cmyk::new`](crate::Cmyk::new) or [`Hsl::new`](crate::Hsl::new),
+		/// both of which perform this check.
+		PercentageOverflow,
+		/// Occurs when a parameter representing a degree value is greater than
+		/// 360. 100. This error can be thrown by
+		/// [`Hsl::new`](crate::Hsl::new), which performs this check.
+		DegreeOverflow,
+	}
 }
+#[cfg(not(feature = "no_std"))]
+mod prelude {
+	use thiserror::Error as ThisError;
+
+	/// Crate-wide Error type.
+	#[derive(ThisError, Debug)]
+	pub enum Error {
+		/// Occurs when a parameter representing a percentage value is greater
+		/// than 100. This error can be thrown by
+		/// [`Cmyk::new`](crate::Cmyk::new) or [`Hsl::new`](crate::Hsl::new),
+		/// both of which perform this check.
+		#[error("Percentage overflow: value is larger than 100!")]
+		PercentageOverflow,
+		/// Occurs when a parameter representing a degree value is greater than
+		/// 360. 100. This error can be thrown by
+		/// [`Hsl::new`](crate::Hsl::new), which performs this check.
+		#[error("Degree overflow: value is larger than 360!")]
+		DegreeOverflow,
+	}
+}
+#[allow(unused_imports)]
+use prelude::*;
+
+pub use prelude::Error;
 
 ///
 /// Unifying `Color` trait which encompasses each of the structs provided by

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,5 +1,7 @@
-use crate::{Cmyk, Color, Hsl};
-use std::fmt;
+#[allow(unused_imports)]
+use crate::prelude::*;
+use crate::{Cmyk, Color, Float, Hsl};
+use core::fmt;
 
 ///
 /// A representation of the RGB (red, green, blue) color format.
@@ -42,22 +44,22 @@ impl Rgb {
 	}
 
 	fn _to_cmyk(self) -> (u8, u8, u8, u8) {
-		let r_prime = self.red as f64 / 255.;
-		let g_prime = self.green as f64 / 255.;
-		let b_prime = self.blue as f64 / 255.;
+		let r_prime = self.red as Float / 255.;
+		let g_prime = self.green as Float / 255.;
+		let b_prime = self.blue as Float / 255.;
 
 		let key = 1.
 			- [r_prime, g_prime, b_prime]
 				.iter()
 				.cloned()
-				.fold(f64::NAN, f64::max);
+				.fold(Float::NAN, Float::max);
 
-		let apply = |v: f64| (((1. - v - key) / (1. - key)) * 100.).round();
+		let apply = |v: Float| (((1. - v - key) / (1. - key)) * 100.).round() as u8;
 		let cyan = apply(r_prime);
 		let magenta = apply(g_prime);
 		let yellow = apply(b_prime);
 
-		(cyan as u8, magenta as u8, yellow as u8, (key * 100.) as u8)
+		(cyan, magenta, yellow, (key * 100.) as u8)
 	}
 }
 
@@ -84,16 +86,16 @@ impl Color for Rgb {
 	fn to_hsl(self) -> Hsl {
 		let Self { red, green, blue } = self;
 
-		let r_prime = red as f64 / 255.;
-		let g_prime = green as f64 / 255.;
-		let b_prime = blue as f64 / 255.;
+		let r_prime = red as Float / 255.;
+		let g_prime = green as Float / 255.;
+		let b_prime = blue as Float / 255.;
 
-		let c_max = [red, green, blue].iter().max().cloned().unwrap() as f64 / 255.;
-		let c_min = [red, green, blue].iter().min().cloned().unwrap() as f64 / 255.;
+		let c_max = [red, green, blue].iter().max().cloned().unwrap() as Float / 255.;
+		let c_min = [red, green, blue].iter().min().cloned().unwrap() as Float / 255.;
 
 		let delta = c_max - c_min;
 
-		let hue = if (delta - 0.) < f64::EPSILON {
+		let hue = if delta.abs() < Float::EPSILON {
 			0
 		} else {
 			match c_max {
@@ -107,7 +109,7 @@ impl Color for Rgb {
 
 		let lightness = (c_max + c_min) / 2.;
 
-		let saturation = if (delta - 0.) < f64::EPSILON {
+		let saturation = if delta.abs() < Float::EPSILON {
 			0
 		} else {
 			(delta / (1. - ((2. * lightness) - 1.)) * 100.).round() as u8


### PR DESCRIPTION
Adds features `std`, `no_std` and `f32`, `std` is enabled by default.

The feature `f32` changes all float operations to use the `f32` type instead of `f64`.
I've duplicated the `Error` enum because rust-analyzer kept crashing with `cfg_attr` attributes.